### PR TITLE
Fix time type (vec4 -> float) in shader

### DIFF
--- a/Sources/pacman.frag.glsl
+++ b/Sources/pacman.frag.glsl
@@ -1,6 +1,6 @@
 #version 450
 
-uniform vec4 time;
+uniform float time;
 
 out vec4 frag;
 


### PR DESCRIPTION
`time` is declared as `vec4` in `pacman.frag.glsl`, it should be `float`

Below the corresponding error message:

```
Solution6/Deployment(master*) » ../build/Exercise6/Exercise6
GLSL linker error: error: uniform `time' declared as type `vec4' and type `float'

Uniform P not found.
Uniform V not found.
Uniform M not found.
Uniform time not found.
Uniform duration not found.
Uniform openAngle not found.
Uniform closeAngle not found.
X Error of failed request:  BadDrawable (invalid Pixmap or Window parameter)
  Major opcode of failed request:  153 (DRI2)
  Minor opcode of failed request:  7 (DRI2GetBuffersWithFormat	)
  Resource id in failed request:  0x3c00003
  Serial number of failed request:  402
  Current serial number in output stream:  402
```